### PR TITLE
Adjust #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # Other common patterns
 .DS_Store
+
+# Local pre-commit config
+.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,0 @@
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
-    hooks:
-      - id: gitleaks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to claude-code.el will be documented in this file.
 ### Added
 - Support for continuing previous conversations with double prefix arg (`C-u C-u`) in `claude-code` and `claude-code-current-directory` commands
     - Uses Claude's `--continue` flag to resume previous sessions
-- Read-only mode for text selection in Claude terminal with `C-c C-e` and `C-c C-j` keybindings
-- Customizable cursor appearance in read-only mode via `claude-code-invisible-cursor-type`
+- Read-only mode for text selection in Claude terminal. Toggle with `claude-code-toggle-read-only-mode`.
+- Customizable cursor appearance in read-only mode via `claude-code-read-only-mode-cursor-type`
 
 ## [0.2.1] - 2025-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [0.2.2] - 2025-05-22
+
+### Added
+- Support for continuing previous conversations with double prefix arg (`C-u C-u`) in `claude-code` and `claude-code-current-directory` commands
+    - Uses Claude's `--continue` flag to resume previous sessions
+
 ## [0.2.1] - 2025-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [0.2.3] - 2025-05-23
+
+### Fixed
+- Fixed Claude buffer jumping to top when editing in other windows (#8)
+
 ## [0.2.2] - 2025-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [0.2.1] - 2025-05-01
+
+### Added
+- Extended `claude-code-fix-error-at-point` to support flymake and any system implementing help-at-pt
+
+### Changed
+- Fixed compiler warnings (thanks to [ncaq](https://github.com/ncaq))
+
 ## [0.2.0] - 2025-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to claude-code.el will be documented in this file.
 
+## [0.3.0] - 2025-06-03
+
+### Changed
+- **New feature**: Launch repository-specific Claude sessions - work on multiple projects simultaneously with separate Claude instances
+- Simplified startup behavior: `claude-code` now automatically detects the appropriate directory (project root, current file directory, or default directory)
+- Removed `claude-code-current-directory` command - its functionality is now integrated into the main `claude-code` command
+- Buffer naming now uses project detection instead of only git repositories
+- Improved error handling: `claude-code-kill` now shows a message instead of throwing an error when Claude is not running
+- Removed startup delay that was used to fix terminal layout issues
+
+### Fixed
+- Fixed defgroup/defface ordering to resolve byte-compilation warnings
+
 ## [0.2.3] - 2025-05-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to claude-code.el will be documented in this file.
+
+## [0.2.0] - 2025-04-22
+
+### Added
+- New `claude-code-fix-error-at-point` function to help fix flycheck errors. A flymake version will come later.
+- Adding option to prompt for extra input in `claude-code-send-region`.
+- Confirm before sending large regions or buffers in `claude-code-send-region`. The customization variable `claude-code-large-buffer-threshold` determines what is "large". 
+- Added gitleaks pre-commit hook for security
+
+### Changed
+- Renamed functions to follow elisp naming conventions:
+  - `claude-fix-error-at-point` → `claude-code-fix-error-at-point`
+  - `claude--format-flycheck-errors-at-point` → `claude-code--format-flycheck-errors-at-point`
+- Removed prefix key customization in favor of manual key binding, fixes #2. 
+- Updated Makefile to disable sentence-end-double-space
+- Enhanced documentation for flycheck integration and build process
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to claude-code.el will be documented in this file.
 ### Added
 - Support for continuing previous conversations with double prefix arg (`C-u C-u`) in `claude-code` and `claude-code-current-directory` commands
     - Uses Claude's `--continue` flag to resume previous sessions
+- Read-only mode for text selection in Claude terminal with `C-c C-e` and `C-c C-j` keybindings
+- Customizable cursor appearance in read-only mode via `claude-code-invisible-cursor-type`
 
 ## [0.2.1] - 2025-05-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,14 @@
 
 ## Build and Test Commands
 - Install package: `M-x package-install-file RET /path/to/claude-code.el`
-- Byte compile: `emacs -Q --batch -f batch-byte-compile claude-code.el`
-- Check package: `emacs -Q --batch -l package-lint.el -f package-lint-batch-and-exit claude-code.el`
-- Lint with checkdoc: `emacs -Q --batch -l checkdoc -f checkdoc-file claude-code.el`
+- Use project Makefile targets (preferred methods):
+  - Byte compile: `make compile`
+  - Lint with checkdoc: `make checkdoc`
+  - Run both checkdoc and compile: `make all`
+- Alternative direct commands:
+  - Byte compile: `emacs -Q --batch -f batch-byte-compile claude-code.el`
+  - Check package: `emacs -Q --batch -l package-lint.el -f package-lint-batch-and-exit claude-code.el`
+  - Lint with checkdoc: `emacs -Q --batch -l checkdoc -f checkdoc-file claude-code.el`
 
 ## Code Style Guidelines
 - Prefix all functions/variables with `claude-code-` (public) or `claude-code--` (private)

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ EL_FILES := $(wildcard *.el)
 
 # Run checkdoc on elisp files. To do this, we run checkdoc-file via -eval on every .el file in EL_FILES
 checkdoc:
-	for FILE in ${EL_FILES}; do $(EMACS) --batch -L . -eval "(checkdoc-file \"$$FILE\")" ; done
+	for FILE in ${EL_FILES}; do $(EMACS) --batch -L . -eval "(setq sentence-end-double-space nil)" -eval "(checkdoc-file \"$$FILE\")" ; done
 
 compile: clean
-	$(EMACS) --batch -L . -f batch-byte-compile *.el
+	$(EMACS) --batch -L . --eval "(setq sentence-end-double-space nil)" -f batch-byte-compile *.el
 
 all: checkdoc compile

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 
 - Emacs 30.0 or higher
 - [Claude Code CLI](https://github.com/anthropics/claude-code) installed and configured
-- Required Emacs packages: transient (0.7.5+), eat (0.9.2+)
+- Required Emacs packages: transient (0.4.0+), eat (0.9.2+)
 
 ### Using package.el with vc-install (Emacs 30+)
 
@@ -82,7 +82,7 @@ The `claude-code` and `claude-code-current-directory` commands support continuin
 - Double prefix arg (`C-u C-u C-c c c`) - Start Claude in project root and continue previous conversation
 - Double prefix arg (`C-u C-u C-c c d`) - Start Claude in current directory and continue previous conversation
 
-This allows you to resume where you left off in your previous Claude session. 
+This allows you to resume where you left off in your previous Claude session.
 
 ### Transient Menus
 
@@ -140,7 +140,18 @@ This layout works best on wide screens.
 
 ### Font Configuration for Better Rendering
 
-Using a font with good Unicode support helps avoid flickering while Claude Code is rendering its thinking icons. [JuliaMono](https://juliamono.netlify.app/) works particularly well. If you want to use JuliaMono just for the Claude Code REPL but use a different font everywhere else you can customize the `claude-code-repl-face`:
+Using a font with good Unicode support helps avoid flickering while Claude Code is rendering its thinking icons. [JuliaMono](https://juliamono.netlify.app/) has excellent Unicode symbols support. To let the Claude Code buffer use Julia Mono for rendering Unicode characters while still using your default font for ASCII characters add this elisp code:
+
+```elisp
+(setq use-default-font-for-symbols nil)
+(set-fontset-font t 'unicode (font-spec :family "JuliaMono"))
+
+;; for emoji characters on MacOS
+(set-fontset-font t 'unicode (font-spec :family "Apple Color Emoji") nil 'append)
+```
+
+If instead you want to use a particular font just for the Claude Code REPL but use a different font
+everywhere else you can customize the `claude-code-repl-face`:
 
 ```elisp
 (custom-set-faces

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 
 ### Basic Commands
 
-- `claude-code` (`C-c c c`) - Start Claude in the current project root
-- `claude-code-current-directory` (`C-c c d`) - Start Claude in the current directory
+- `claude-code` (`C-c c c`) - Start Claude 
 - `claude-code-toggle` (`C-c c t`) - Toggle Claude window
 - `claude-code-switch-to-buffer` (`C-c c b`) - Switch to the Claude buffer
 - `claude-code-kill` (`C-c c k`) - Kill Claude session
@@ -58,7 +57,11 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-send-return` (`C-c c y`) - Send return key to Claude (useful for confirming with Claude without switching to the Claude REPL buffer)
 - `claude-code-send-escape` (`C-c c n`) - Send escape key to Claude (useful for saying "No" when Claude asks for confirmation without switching to the Claude REPL buffer)
 
-With a prefix arg, `claude-code`, `claude-code-current-directory`, `claude-code-send-command` and `claude-code-send-command-with-context` will switch to the Claude terminal buffer after sending the command.
+With a single prefix arg, `claude-code`, `claude-code-send-command` and
+`claude-code-send-command-with-context` will switch to the Claude terminal buffer after sending the
+command.
+
+
 
 ### Read-Only Mode Toggle
 
@@ -74,10 +77,10 @@ The command automatically detects the current mode and switches to the other:
 
 ### Continuing Previous Conversations
 
-The `claude-code` and `claude-code-current-directory` commands support continuing previous conversations using Claude's `--continue` flag:
+The `claude-code` command supports continuing previous conversations using Claude's `--continue`
+flag:
 
 - Double prefix arg (`C-u C-u C-c c c`) - Start Claude in project root and continue previous conversation
-- Double prefix arg (`C-u C-u C-c c d`) - Start Claude in current directory and continue previous conversation
 
 This allows you to resume where you left off in your previous Claude session.
 
@@ -127,7 +130,7 @@ You can control how the Claude Code window appears using Emacs' `display-buffer-
 
 ```elisp
 (add-to-list 'display-buffer-alist
-             '("^\\*claude\\*"
+             '("^\\*claude"
                (display-buffer-in-side-window)
                (side . right)
                (window-width . 0.33)))

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
 - `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
-- `claude-code-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (works with flycheck if available)
+- `claude-code-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (works with flycheck, flymake, and any system that implements help-at-pt)
 - `claude-code-slash-commands` (`C-c c /`) - Access Claude slash commands menu
 - `claude-code-transient` (`C-c c m`) - Show all commands (transient menu)
 - `claude-code-send-return` (`C-c c y`) - Send return key to Claude (useful for confirming with Claude without switching to the Claude REPL buffer)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
 - `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
-- `claude-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (requires flycheck)
+- `claude-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (works with flycheck if available)
 - `claude-code-slash-commands` (`C-c c /`) - Access Claude slash commands menu
 - `claude-code-transient` (`C-c c m`) - Show all commands (transient menu)
 - `claude-code-send-return` (`C-c c y`) - Send return key to Claude (useful for confirming with Claude without switching to the Claude REPL buffer)

--- a/README.md
+++ b/README.md
@@ -17,16 +17,13 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 - [Claude Code CLI](https://github.com/anthropics/claude-code) installed and configured
 - Required Emacs packages: transient (0.7.5+), eat (0.9.2+)
 
-### Using package.el with vc-install (Emacs 30+)
+### Using builtin use-package (Emacs 30+)
 
 ```elisp
-;; Install directly from GitHub
-(package-vc-install '(claude-code :url "https://github.com/stevemolitor/claude-code.el"))
-
-;; Then in your init.el:
-(require 'claude-code)
-(global-set-key (kbd "C-c c") claude-code-command-map) ;; or your preferred key
-(claude-code-mode)
+(use-package claude-code :ensure t
+  :vc (:url "https://github.com/stevemolitor/claude-code.el" :rev :newest)
+  :config (claude-code-mode)
+  :bind-keymap ("C-c c" . claude-code-command-map)) ;; or your preferred key
 ```
 
 ### Using straight.el

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
 - `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
-- `claude-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (works with flycheck if available)
+- `claude-code-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (works with flycheck if available)
 - `claude-code-slash-commands` (`C-c c /`) - Access Claude slash commands menu
 - `claude-code-transient` (`C-c c m`) - Show all commands (transient menu)
 - `claude-code-send-return` (`C-c c y`) - Send return key to Claude (useful for confirming with Claude without switching to the Claude REPL buffer)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 
 ;; Then in your init.el:
 (require 'claude-code)
-(setq claude-code-prefix-key "C-c c")
-(define-key global-map (kbd "C-c c") claude-code-command-map)
+(global-set-key (kbd "C-c c") claude-code-command-map) ;; or your preferred key
 (claude-code-mode)
 ```
 
@@ -45,7 +44,7 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
 
 ## Usage
 
-The default prefix key for all Claude Code commands is `C-c c`. This can be customized with `claude-code-prefix-key`.
+You need to set your own key binding for the Claude Code command map. The examples in this README use `C-c c` as the prefix key.
 
 ### Basic Commands
 
@@ -76,8 +75,8 @@ For quick access to Claude slash commands like `/help`, `/clear`, or `/compact`,
 ## Customization
 
 ```elisp
-;; Change the prefix key
-(setq claude-code-prefix-key "C-c C-a")
+;; Set your key binding for the command map
+(global-set-key (kbd "C-c C-a") claude-code-command-map)
 
 ;; Set terminal type for the Claude terminal emulation (default is "xterm-256color")
 ;; This determines terminal capabilities like color support

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ You need to set your own key binding for the Claude Code command map. The exampl
 
 With a prefix arg, `claude-code`, `claude-code-current-directory`, `claude-code-send-command` and `claude-code-send-command-with-context` will switch to the Claude terminal buffer after sending the command.
 
+### Read-Only Mode Toggle
+
+The `claude-code-toggle-read-only-mode` command provides a convenient way to switch between normal terminal mode and read-only mode in the Claude buffer:
+
+- `claude-code-toggle-read-only-mode` - Toggle between read-only mode and normal mode
+
+In read-only mode, you can interact with the terminal buffer just like a regular Emacs buffer, making it easy to select and copy text. However, you cannot change the buffer contents or enter Claude commands in this mode. This is particularly useful when you need to copy output from Claude without accidentally modifying the terminal.
+
+The command automatically detects the current mode and switches to the other:
+- If in normal terminal mode (semi-char mode), it switches to read-only mode
+- If in read-only mode (emacs mode), it switches back to normal terminal mode
+
 ### Continuing Previous Conversations
 
 The `claude-code` and `claude-code-current-directory` commands support continuing previous conversations using Claude's `--continue` flag:
@@ -157,12 +169,12 @@ In the Claude terminal, you can switch to a read-only mode to select and copy te
 - `C-c C-e` (`eat-emacs-mode`) - Switch to read-only mode with normal Emacs cursor for text selection
 - `C-c C-j` (`semi-char-mode`) - Return to normal terminal mode
 
-The cursor appearance in read-only mode can be customized via the `claude-code-invisible-cursor-type` variable:
+The cursor appearance in read-only mode can be customized via the `claude-code-read-only-mode-cursor-type` variable:
 
 ```elisp
 ;; Customize cursor type in read-only mode (default is 'box)
 ;; Options: 'box, 'hollow, 'bar, 'hbar, or nil
-(setq claude-code-invisible-cursor-type 'bar)
+(setq claude-code-read-only-mode-cursor-type 'bar)
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The default prefix key for all Claude Code commands is `C-c c`. This can be cust
 - `claude-code-kill` (`C-c c k`) - Kill Claude session
 - `claude-code-send-command` (`C-c c s`) - Send command to Claude
 - `claude-code-send-command-with-context` (`C-c c x`) - Send command with current file and line context
-- `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude
+- `claude-code-send-region` (`C-c c r`) - Send the current region or buffer to Claude. With prefix arg (`C-u`), prompts for instructions to add to the text. With double prefix (`C-u C-u`), adds instructions and switches to Claude buffer
 - `claude-fix-error-at-point` (`C-c c e`) - Ask Claude to fix the error at the current point (requires flycheck)
 - `claude-code-slash-commands` (`C-c c /`) - Access Claude slash commands menu
 - `claude-code-transient` (`C-c c m`) - Show all commands (transient menu)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ This [demo](./demo.gif) shows claude-code.el in action, including toggling the C
 
 Check out this [video demo](https://www.youtube.com/watch?v=K8sCVLmFyyU) demonstrating the claude-code.el package. This video was kindly created and shared by a user of the package.
 
+### Read-Only Mode for Text Selection
+
+In the Claude terminal, you can switch to a read-only mode to select and copy text:
+
+- `C-c C-e` (`eat-emacs-mode`) - Switch to read-only mode with normal Emacs cursor for text selection
+- `C-c C-j` (`semi-char-mode`) - Return to normal terminal mode
+
+The cursor appearance in read-only mode can be customized via the `claude-code-invisible-cursor-type` variable:
+
+```elisp
+;; Customize cursor type in read-only mode (default is 'box)
+;; Options: 'box, 'hollow, 'bar, 'hbar, or nil
+(setq claude-code-invisible-cursor-type 'bar)
+```
+
 ## Limitations
 
 - Currently, `claude-code.el` only supports running one Claude Code process at a time.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,16 @@ You need to set your own key binding for the Claude Code command map. The exampl
 - `claude-code-send-return` (`C-c c y`) - Send return key to Claude (useful for confirming with Claude without switching to the Claude REPL buffer)
 - `claude-code-send-escape` (`C-c c n`) - Send escape key to Claude (useful for saying "No" when Claude asks for confirmation without switching to the Claude REPL buffer)
 
-With a prefix arg, `claude-code`, `claude-code-current-directory`, `claude-code-send-command` and `claude-code-send-command-with-context` will switch to the Claude terminal buffer after sending the command. 
+With a prefix arg, `claude-code`, `claude-code-current-directory`, `claude-code-send-command` and `claude-code-send-command-with-context` will switch to the Claude terminal buffer after sending the command.
+
+### Continuing Previous Conversations
+
+The `claude-code` and `claude-code-current-directory` commands support continuing previous conversations using Claude's `--continue` flag:
+
+- Double prefix arg (`C-u C-u C-c c c`) - Start Claude in project root and continue previous conversation
+- Double prefix arg (`C-u C-u C-c c d`) - Start Claude in current directory and continue previous conversation
+
+This allows you to resume where you left off in your previous Claude session. 
 
 ### Transient Menus
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ An Emacs interface for [Claude Code CLI](https://github.com/anthropics/claude-co
                    :files ("*.el" (:exclude "demo.gif")))
   :bind-keymap
   ("C-c c" . claude-code-command-map)
-  :hook ((claude-code--start . sm-setup-claude-faces))
   :config
   (claude-code-mode))
 ```

--- a/claude-code.el
+++ b/claude-code.el
@@ -65,6 +65,58 @@ These are passed as SWITCHES parameters to `eat-make`."
   :type '(repeat string)
   :group 'claude-code)
 
+(defcustom claude-code-invisible-cursor-type '(box nil nil)
+  "Type of cursor to use as invisible cursor in Claude Code terminal buffer.
+
+The value is a list of form (CURSOR-ON BLINKING-FREQUENCY CURSOR-OFF).
+
+When the cursor is on, CURSOR-ON is used as `cursor-type', which see.
+BLINKING-FREQUENCY is the blinking frequency of cursor's blinking.
+When the cursor is off, CURSOR-OFF is used as `cursor-type'.  This
+should be nil when cursor is not blinking.
+
+Valid cursor types for CURSOR-ON and CURSOR-OFF:
+- t: Frame default cursor
+- box: Filled box cursor
+- (box . N): Box cursor with specified size N
+- hollow: Hollow cursor
+- bar: Vertical bar cursor
+- (bar . N): Vertical bar with specified height N
+- hbar: Horizontal bar cursor
+- (hbar . N): Horizontal bar with specified width N
+- nil: No cursor
+
+BLINKING-FREQUENCY can be nil (no blinking) or a number."
+  :type '(list
+          (choice
+           (const :tag "Frame default" t)
+           (const :tag "Filled box" box)
+           (cons :tag "Box with specified size" (const box) integer)
+           (const :tag "Hollow cursor" hollow)
+           (const :tag "Vertical bar" bar)
+           (cons :tag "Vertical bar with specified height" (const bar)
+                 integer)
+           (const :tag "Horizontal bar" hbar)
+           (cons :tag "Horizontal bar with specified width"
+                 (const hbar) integer)
+           (const :tag "None" nil))
+          (choice
+           (const :tag "No blinking" nil)
+           (number :tag "Blinking frequency"))
+          (choice
+           (const :tag "Frame default" t)
+           (const :tag "Filled box" box)
+           (cons :tag "Box with specified size" (const box) integer)
+           (const :tag "Hollow cursor" hollow)
+           (const :tag "Vertical bar" bar)
+           (cons :tag "Vertical bar with specified height" (const bar)
+                 integer)
+           (const :tag "Horizontal bar" hbar)
+           (cons :tag "Horizontal bar with specified width"
+                 (const hbar) integer)
+           (const :tag "None" nil)))
+  :group 'claude-code)
+
 ;; Forward declare variables to avoid compilation warnings
 (defvar eat-terminal)
 (defvar eat-term-name)
@@ -196,6 +248,7 @@ With non-nil CONTINUE, start Claude with --continue flag to continue previous co
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
+      (setq-local eat-invisible-cursor-type claude-code-invisible-cursor-type)
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))

--- a/claude-code.el
+++ b/claude-code.el
@@ -291,14 +291,13 @@ possible, preventing the scrolling up issue when editing other buffers."
 (defun claude-code--on-window-configuration-change ()
   "Handle window configuration changes for Claude buffer.
 
-Ensures the Claude buffer stays scrolled to the bottom when window
+Ensures the Claude buffer stays scrolled to the bottom when window all
 configuration changes (e.g., when minibuffer opens/closes)."
   (when-let ((claude-buffer (claude-code--get-claude-buffer)))
     (with-current-buffer claude-buffer
       ;; Get all windows showing the Claude buffer
-      (let ((windows (get-buffer-window-list claude-buffer nil t)))
-        (when windows
-          (claude-code--synchronize-scroll windows))))))
+      (if-let ((windows (get-buffer-window-list claude-buffer nil t)))
+        (claude-code--synchronize-scroll windows)))))
 
 (defun claude-code--start (dir &optional arg continue)
   "Start Claude in directory DIR.

--- a/claude-code.el
+++ b/claude-code.el
@@ -252,6 +252,7 @@ With non-nil CONTINUE, start Claude with --continue flag to continue previous co
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))
+      (setq-local eat-invisible-cursor-type claude-code-invisible-cursor-type)
       (setq-local eat-term-name claude-code-term-name)
       (claude-code--setup-repl-faces)
       (run-hooks 'claude-code-start-hook)

--- a/claude-code.el
+++ b/claude-code.el
@@ -315,7 +315,7 @@ conversation."
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
-     ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type
+      ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))

--- a/claude-code.el
+++ b/claude-code.el
@@ -261,7 +261,7 @@ conversation."
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
-      (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
+     ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))

--- a/claude-code.el
+++ b/claude-code.el
@@ -315,7 +315,6 @@ conversation."
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
-      ;; (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))

--- a/claude-code.el
+++ b/claude-code.el
@@ -261,7 +261,7 @@ conversation."
                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
-      (setq-local eat-invisible-cursor-type claude-code-invisible-cursor-type)
+      (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
         (apply #'eat-make "claude" claude-code-program nil program-switches))

--- a/claude-code.el
+++ b/claude-code.el
@@ -31,12 +31,6 @@
   :type 'string
   :group 'claude-code)
 
-;;;###autoload (autoload 'claude-code-prefix-key "claude-code")
-(defcustom claude-code-prefix-key "C-c c"
-  "Prefix key for Claude commands."
-  :type 'string
-  :group 'claude-code)
-
 (defcustom claude-code-start-hook nil
   "Hook run after Claude is started."
   :type 'hook
@@ -205,8 +199,7 @@ With non-nil ARG, switch to the Claude buffer after starting."
       (switch-to-buffer buffer))))
 
 (defun claude--format-flycheck-errors-at-point ()
-  "Format the flycheck errors at point as a string with file and line
-  numbers."
+  "Format the flycheck errors at point as a string with file and line numbers."
   (interactive)
   (let ((errors (flycheck-overlay-errors-at (point)))
         (result ""))
@@ -242,8 +235,9 @@ With prefix ARG, prompt for the project directory."
 If no region is active, send the entire buffer if it's not too large.
 For large buffers, ask for confirmation first.
 
-With prefix ARG, prompt for instructions to add to the text before sending.
-With two prefix ARGs (C-u C-u), both add instructions and switch to Claude buffer."
+With prefix ARG, prompt for instructions to add to the text before
+sending.   With two prefix ARGs (C-u C-u), both add instructions and
+switch to Claude buffer."
   (interactive "P")
   (let* ((text (if (use-region-p)
                    (buffer-substring-no-properties (region-beginning) (region-end))
@@ -251,13 +245,13 @@ With two prefix ARGs (C-u C-u), both add instructions and switch to Claude buffe
                      (when (yes-or-no-p "Buffer is large.  Send anyway? ")
                        (buffer-substring-no-properties (point-min) (point-max)))
                    (buffer-substring-no-properties (point-min) (point-max)))))
-         (prompt (cond 
+         (prompt (cond
                   ((equal arg '(4)) ; C-u
                    (read-string "Instructions for Claude: "))
                   ((equal arg '(16)) ; C-u C-u
                    (read-string "Instructions for Claude: "))
                   (t nil)))
-         (full-text (if prompt 
+         (full-text (if prompt
                         (format "%s\n\n%s" prompt text)
                       text)))
     (when full-text
@@ -385,15 +379,13 @@ With prefix ARG, switch to the Claude buffer after sending."
 (define-minor-mode claude-code-mode
   "Minor mode for interacting with Claude AI CLI.
 
-When enabled, provides keybindings for starting, sending commands to,
-and managing Claude sessions."
+When enabled, provides functionality for starting, sending commands to,
+and managing Claude sessions.  No default keybindings are set.  Users
+should set their own bindings to `claude-code-command-map`."
   :init-value nil
   :lighter " Claude"
   :global t
-  :group 'claude-code
-  (if claude-code-mode
-      (global-set-key (kbd claude-code-prefix-key) claude-code-command-map)
-    (global-unset-key (kbd claude-code-prefix-key))))
+  :group 'claude-code)
 
 ;;;; Provide the feature
 (provide 'claude-code)

--- a/claude-code.el
+++ b/claude-code.el
@@ -293,15 +293,12 @@ possible, preventing the scrolling up issue when editing other buffers."
 
 Ensures the Claude buffer stays scrolled to the bottom when window
 configuration changes (e.g., when minibuffer opens/closes)."
-  (when (and (eq (current-buffer) (claude-code--get-claude-buffer))
-             (derived-mode-p 'eat-mode))
-    ;; Get all windows showing the Claude buffer
-    (let ((windows (get-buffer-window-list (current-buffer) nil t)))
-      (dolist (window windows)
-        ;; Move to end of buffer to show latest output
-        (with-selected-window window
-          (goto-char (point-max))
-          (recenter -1))))))
+  (when-let ((claude-buffer (claude-code--get-claude-buffer)))
+    (with-current-buffer claude-buffer
+      ;; Get all windows showing the Claude buffer
+      (let ((windows (get-buffer-window-list claude-buffer nil t)))
+        (when windows
+          (claude-code--synchronize-scroll windows))))))
 
 (defun claude-code--start (dir &optional arg continue)
   "Start Claude in directory DIR.

--- a/claude-code.el
+++ b/claude-code.el
@@ -16,7 +16,6 @@
 (require 'transient)
 (require 'project)
 (require 'cl-lib)
-(require 'vc-git)
 
 ;; Declare external variables and functions from eat package
 (defvar eat--semi-char-mode)
@@ -220,7 +219,7 @@ BLINKING-FREQUENCY can be nil (no blinking) or a number."
 (defun claude-code--buffer-name ()
   "Generate the Claude buffer name based on git repo or current buffer file path.
 If not in a git repository and no buffer file exists, returns default name."
-  (let ((git-repo-path (vc-git-root default-directory))
+  (let ((git-repo-path (project-root (project-current t)))
         (current-file (buffer-file-name)))
     (cond
      ;; Case 1: Valid git repo path

--- a/claude-code.el
+++ b/claude-code.el
@@ -1,7 +1,7 @@
 ;;; claude-code.el --- Claude Code Emacs integration -*- lexical-binding: t; -*-
 
 ;; Author: Stephen Molitor <stevemolitor@gmail.com>
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "30.0") (transient "0.7.5") (eat "0.9.2"))
 ;; Keywords: tools, ai
 ;; URL: https://github.com/stevemolitor/claude-code.el

--- a/claude-code.el
+++ b/claude-code.el
@@ -28,14 +28,14 @@
 (declare-function eat-term-display-beginning "eat" (terminal))
 
 ;;;; Customization options
-(defgroup claude-code nil
-  "Claude AI interface for Emacs."
-  :group 'tools)
-
 (defface claude-code-repl-face
   nil
   "Face for Claude REPL."
   :group 'claude-code)
+
+(defgroup claude-code nil
+  "Claude AI interface for Emacs."
+  :group 'tools)
 
 (defcustom claude-code-term-name "xterm-256color"
   "Terminal type to use for Claude REPL."
@@ -127,9 +127,6 @@ BLINKING-FREQUENCY can be nil (no blinking) or a number."
            (const :tag "None" nil)))
   :group 'claude-code)
 
-(defvar claude-code--claude-buffer "*claude*"
-  "Name of the Claude buffer.")
-
 ;; Forward declare variables to avoid compilation warnings
 (defvar eat-terminal)
 (defvar eat-term-name)
@@ -173,7 +170,6 @@ BLINKING-FREQUENCY can be nil (no blinking) or a number."
   "Claude command menu."
   ["Claude Commands"
    ["Manage Claude" ("c" "Start Claude" claude-code)
-    ("d" "Start Claude in current directory" claude-code-current-directory)
     ("t" "Toggle claude window" claude-code-toggle)
     ("b" "Switch to Claude buffer" claude-code-switch-to-buffer)
     ("k" "Kill Claude" claude-code-kill)
@@ -216,22 +212,28 @@ BLINKING-FREQUENCY can be nil (no blinking) or a number."
    ])
 
 ;;;; Private util functions
-(defun claude-code--buffer-name ()
-  "Generate the Claude buffer name based on git repo or current buffer file path.
-If not in a git repository and no buffer file exists, returns default name."
-  (let ((git-repo-path (project-root (project-current t)))
-        (current-file (buffer-file-name)))
+(defun claude-code--directory ()
+  "Get get the root Claude directory for the current buffer.
+   
+If not in a project and no buffer file return `default-directory'."
+  (let* ((project (project-current))
+         (current-file (buffer-file-name)))
     (cond
-     ;; Case 1: Valid git repo path
-     (git-repo-path
-      (format "*claude:%s*" (file-truename git-repo-path)))
-     ;; Case 2: Has buffer file (when not in git repo)
-     (current-file
-      (format "*claude:%s*"
-              (file-truename (file-name-directory current-file))))
-     ;; Case 3: No git repo and no buffer file
-     (t
-      "*claude*"))))
+     ;; Case 1: In a project
+     (project (project-root project))
+     ;; Case 2: Has buffer file (when not in VC repo)
+     (current-file (file-name-directory current-file))
+     ;; Case 3: No project and no buffer file
+     (t default-directory))))
+
+(defun claude-code--buffer-name ()
+  "Generate the Claude buffer name based on project or current buffer file.
+   
+If not in a project and no buffer file, return \"*claude*\"."
+  (let ((dir (claude-code--directory)))
+    (if dir
+        (format "*claude:%s*" dir)
+      "*claude*")))
 
 (defun claude-code--do-send-command (cmd)
   "Send a command CMD to Claude if Claude buffer exists.
@@ -300,30 +302,39 @@ possible, preventing the scrolling up issue when editing other buffers."
 (defun claude-code--on-window-configuration-change ()
   "Handle window configuration changes for Claude buffer.
 
-Ensures the Claude buffer stays scrolled to the bottom when window all
+Ensures the Claude buffer stays scrolled to the bottom when window
 configuration changes (e.g., when minibuffer opens/closes)."
-  (when-let ((claude-buffer (claude-code--get-claude-buffer)))
-    (with-current-buffer claude-buffer
+  (when-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
+    (with-current-buffer claude-code-buffer
       ;; Get all windows showing the Claude buffer
-      (if-let ((windows (get-buffer-window-list claude-buffer nil t)))
+      (if-let ((windows (get-buffer-window-list claude-code-buffer nil t)))
         (claude-code--synchronize-scroll windows)))))
 
-(defun claude-code--start (dir &optional arg continue)
-  "Start Claude in directory DIR.
+(defun claude-code (&optional arg)
+  "Start Claude in an eat terminal and enable `claude-code-mode'.
 
-With non-nil ARG, switch to the Claude buffer after starting. With
-non-nil CONTINUE, start Claude with --continue flag to continue previous
-conversation."
+If current buffer belongs to a project start Claude in the project's
+root directory. Otherwise start in the directory of the current buffer
+file, or the current value of `default-directory' if no project and no
+buffer file.
+
+With single prefix ARG (C-u), prompt for the project directory.
+With double prefix ARG (C-u C-u), continue previous conversation."
+  (interactive "P")
+  
   ;; Forward declare variables to avoid compilation warnings
   (require 'eat)
   
-  (let* ((default-directory dir)
+  (let* ((dir (if (and arg (not (equal arg '(16))))
+                  (read-directory-name "Project directory: ")
+                (claude-code--directory)))
+         (continue (equal arg '(16)))(default-directory dir)
          (buffer-name (claude-code--buffer-name))
          (trimmed-buffer-name (string-trim-right (string-trim buffer-name "\\*") "\\*"))
          (buffer (get-buffer-create buffer-name))
          (program-switches (if continue
-                              (append claude-code-program-switches '("--continue"))
-                            claude-code-program-switches)))
+                               (append claude-code-program-switches '("--continue"))
+                             claude-code-program-switches)))
     (with-current-buffer buffer
       (cd dir)
       (setq-local eat-term-name claude-code-term-name)
@@ -332,12 +343,11 @@ conversation."
       (claude-code--setup-repl-faces)
       ;; Set our custom synchronize scroll function
       (setq-local eat--synchronize-scroll-function #'claude-code--synchronize-scroll)
+
       ;; Add window configuration change hook to keep buffer scrolled to bottom
       (add-hook 'window-configuration-change-hook #'claude-code--on-window-configuration-change nil t)
-      (run-hooks 'claude-code-start-hook)
 
-      ;; fix wonky initial terminal layout that happens sometimes if we show the buffer before claude is ready
-      (sleep-for claude-code-startup-delay)
+      (run-hooks 'claude-code-start-hook)
       (display-buffer buffer))
     (when arg
       (switch-to-buffer buffer))))
@@ -376,17 +386,17 @@ Returns a string with the errors or a message if no errors found."
 
 ;;;; Interactive Commands
 ;;;###autoload
-(defun claude-code (&optional arg)
-  "Start Claude in an eat terminal and enable `claude-code-mode'.
+;; (defun claude-code (&optional arg)
+;;   "Start Claude in an eat terminal and enable `claude-code-mode'.
 
-With single prefix ARG (C-u), prompt for the project directory.
-With double prefix ARG (C-u C-u), continue previous conversation."
-  (interactive "P")
-  (let* ((dir (if (and arg (not (equal arg '(16))))
-                  (read-directory-name "Project directory: ")
-                (funcall #'project-root (project-current t))))
-         (continue (equal arg '(16))))
-    (claude-code--start dir arg continue)))
+;; With single prefix ARG (C-u), prompt for the project directory.
+;; With double prefix ARG (C-u C-u), continue previous conversation."
+;;   (interactive "P")
+;;   (let* ((dir (if (and arg (not (equal arg '(16))))
+;;                   (read-directory-name "Project directory: ")
+;;                 (funcall #'project-root (project-current t))))
+;;          (continue (equal arg '(16))))
+;;     (claude-code--start dir arg continue)))
 
 ;;;###autoload
 (defun claude-code-send-region (&optional arg)
@@ -420,16 +430,6 @@ switch to Claude buffer."
         (switch-to-buffer (claude-code--buffer-name))))))
 
 ;;;###autoload
-(defun claude-code-current-directory (&optional arg)
-  "Start Claude in the current directory.
-
-With single prefix ARG (C-u), switch to the Claude buffer after starting.
-With double prefix ARG (C-u C-u), continue previous conversation."
-  (interactive "P")
-  (let ((continue (equal arg '(16))))
-    (claude-code--start default-directory arg continue)))
-
-;;;###autoload
 (defun claude-code-toggle ()
   "Show or hide the Claude window.
 
@@ -459,7 +459,7 @@ If the Claude buffer doesn't exist, create it."
                (eat-kill-process)
                (kill-buffer claude-code-buffer))
              (message "Claude killed"))
-    (error "Claude is not running")))
+    (message "Claude is not running")))
 
 ;;;###autoload
 (defun claude-code-send-command (cmd &optional arg)

--- a/claude-code.el
+++ b/claude-code.el
@@ -98,7 +98,7 @@ These are passed as SWITCHES parameters to `eat-make`."
   "Keymap for Claude commands.")
 
 ;;;; Transient Menus
-;;;###autoload
+;;;###autoload (autoload 'claude-code-transient "claude-code" nil t)
 (transient-define-prefix claude-code-transient ()
   "Claude command menu."
   ["Claude Commands"
@@ -114,7 +114,7 @@ These are passed as SWITCHES parameters to `eat-make`."
     ("n" "Send <escape> to Claude (\"No\")" claude-code-send-escape)
     ("/" "Slash Commands" claude-code-slash-commands)]])
 
-;;;###autoload
+;;;###autoload (autoload 'claude-code-slash-commands "claude-code" nil t)
 (transient-define-prefix claude-code-slash-commands ()
   "Claude slash commands menu."
   ["Slash Commands"

--- a/claude-code.el
+++ b/claude-code.el
@@ -99,7 +99,7 @@ These are passed as SWITCHES parameters to `eat-make`."
   "Keymap for Claude commands.")
 
 ;;;; Transient Menus
-;;;###autoload
+;;;###autoload (autoload 'claude-code-transient "claude-code" nil t)
 (transient-define-prefix claude-code-transient ()
   "Claude command menu."
   ["Claude Commands"
@@ -116,7 +116,7 @@ These are passed as SWITCHES parameters to `eat-make`."
     ("n" "Send <escape> to Claude (\"No\")" claude-code-send-escape)
     ("/" "Slash Commands" claude-code-slash-commands)]])
 
-;;;###autoload
+;;;###autoload (autoload 'claude-code-slash-commands "claude-code" nil t)
 (transient-define-prefix claude-code-slash-commands ()
   "Claude slash commands menu."
   ["Slash Commands"

--- a/claude-code.el
+++ b/claude-code.el
@@ -94,7 +94,7 @@ These are passed as SWITCHES parameters to `eat-make`."
     (define-key map "y" 'claude-code-send-return)
     (define-key map "n" 'claude-code-send-escape)
     (define-key map "r" 'claude-code-send-region)
-    (define-key map "e" 'claude-fix-error-at-point)
+    (define-key map "e" 'claude-code-fix-error-at-point)
     map)
   "Keymap for Claude commands.")
 
@@ -111,7 +111,7 @@ These are passed as SWITCHES parameters to `eat-make`."
    ["Send Commands to Claude" ("s" "Send command" claude-code-send-command)
     ("x" "Send command with context" claude-code-send-command-with-context)
     ("r" "Send region or buffer" claude-code-send-region)
-    ("e" "Fix error at point" claude-fix-error-at-point)
+    ("e" "Fix error at point" claude-code-fix-error-at-point)
     ("y" "Send <return> to Claude (\"Yes\")" claude-code-send-return)
     ("n" "Send <escape> to Claude (\"No\")" claude-code-send-escape)
     ("/" "Slash Commands" claude-code-slash-commands)]])
@@ -205,7 +205,7 @@ With non-nil ARG, switch to the Claude buffer after starting."
     (when arg
       (switch-to-buffer buffer))))
 
-(defun claude--format-flycheck-errors-at-point ()
+(defun claude-code--format-flycheck-errors-at-point ()
   "Format the flycheck errors at point as a string with file and line numbers.
 Returns a string with the errors or a message if flycheck is not available."
   (interactive)
@@ -368,7 +368,7 @@ having to switch to the REPL buffer."
     (error "Claude is not running")))
 
 ;;;###autoload
-(defun claude-fix-error-at-point (&optional arg)
+(defun claude-code-fix-error-at-point (&optional arg)
   "Ask Claude to fix the error at point.
 
 Gets the error message, file name, and line number, and instructs Claude
@@ -379,9 +379,9 @@ With prefix ARG, switch to the Claude buffer after sending."
   (interactive "P")
   (unless (bound-and-true-p flycheck-mode)
     (message "Flycheck mode is not enabled in this buffer.")
-    (cl-return-from claude-fix-error-at-point))
+    (cl-return-from claude-code-fix-error-at-point))
   
-  (let* ((error-text (claude--format-flycheck-errors-at-point))
+  (let* ((error-text (claude-code--format-flycheck-errors-at-point))
          (file-name (when (buffer-file-name)
                       (file-relative-name (buffer-file-name) (project-root (project-current t))))))
     (if (string= error-text "No errors at point")

--- a/claude-code.el
+++ b/claude-code.el
@@ -16,6 +16,7 @@
 (require 'transient)
 (require 'project)
 (require 'cl-lib)
+(require 'vc-git)
 
 ;; Declare external variables and functions from eat package
 (defvar eat--semi-char-mode)
@@ -216,19 +217,28 @@ BLINKING-FREQUENCY can be nil (no blinking) or a number."
    ])
 
 ;;;; Private util functions
-(defun claude-code--get-claude-buffer ()
-  "Return the Claude buffer if it exists, nil otherwise."
-  (get-buffer claude-code--claude-buffer))
-
-(defun claude-code--switch-to-claude-buffer ()
-  "Switch to the Claude buffer."
-  (switch-to-buffer claude-code--claude-buffer))
+(defun claude-code--buffer-name ()
+  "Generate the Claude buffer name based on git repo or current buffer file path.
+If not in a git repository and no buffer file exists, returns default name."
+  (let ((git-repo-path (vc-git-root default-directory))
+        (current-file (buffer-file-name)))
+    (cond
+     ;; Case 1: Valid git repo path
+     (git-repo-path
+      (format "*claude:%s*" (file-truename git-repo-path)))
+     ;; Case 2: Has buffer file (when not in git repo)
+     (current-file
+      (format "*claude:%s*"
+              (file-truename (file-name-directory current-file))))
+     ;; Case 3: No git repo and no buffer file
+     (t
+      "*claude*"))))
 
 (defun claude-code--do-send-command (cmd)
   "Send a command CMD to Claude if Claude buffer exists.
 
 After sending the command, move point to the end of the buffer."
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
       (with-current-buffer claude-code-buffer
         (eat-term-send-string eat-terminal cmd)
         (eat-term-send-string eat-terminal (kbd "RET"))
@@ -309,7 +319,9 @@ conversation."
   (require 'eat)
   
   (let* ((default-directory dir)
-         (buffer (get-buffer-create claude-code--claude-buffer))
+         (buffer-name (claude-code--buffer-name))
+         (trimmed-buffer-name (string-trim-right (string-trim buffer-name "\\*") "\\*"))
+         (buffer (get-buffer-create buffer-name))
          (program-switches (if continue
                               (append claude-code-program-switches '("--continue"))
                             claude-code-program-switches)))
@@ -317,7 +329,7 @@ conversation."
       (cd dir)
       (setq-local eat-term-name claude-code-term-name)
       (let ((process-adaptive-read-buffering nil))
-        (apply #'eat-make "claude" claude-code-program nil program-switches))
+        (apply #'eat-make trimmed-buffer-name claude-code-program nil program-switches))
       (claude-code--setup-repl-faces)
       ;; Set our custom synchronize scroll function
       (setq-local eat--synchronize-scroll-function #'claude-code--synchronize-scroll)
@@ -406,7 +418,7 @@ switch to Claude buffer."
     (when full-text
       (claude-code--do-send-command full-text)
       (when (equal arg '(16)) ; Only switch buffer with C-u C-u
-        (claude-code--switch-to-claude-buffer)))))
+        (switch-to-buffer (claude-code--buffer-name))))))
 
 ;;;###autoload
 (defun claude-code-current-directory (&optional arg)
@@ -424,7 +436,7 @@ With double prefix ARG (C-u C-u), continue previous conversation."
 
 If the Claude buffer doesn't exist, create it."
   (interactive)
-  (let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
     (if claude-code-buffer
         (if (get-buffer-window claude-code-buffer)
             (delete-window (get-buffer-window claude-code-buffer))
@@ -435,15 +447,15 @@ If the Claude buffer doesn't exist, create it."
 (defun claude-code-switch-to-buffer ()
   "Switch to the Claude buffer if it exists."
   (interactive)
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
-      (claude-code--switch-to-claude-buffer)
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
+      (switch-to-buffer claude-code-buffer)
     (error "Claude is not running")))
 
 ;;;###autoload
 (defun claude-code-kill ()
   "Kill Claude process and close its window."
   (interactive)
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
       (progn (with-current-buffer claude-code-buffer
                (eat-kill-process)
                (kill-buffer claude-code-buffer))
@@ -458,7 +470,7 @@ With prefix ARG, switch to the Claude buffer after sending CMD."
   (interactive "sClaude command: \nP")
   (claude-code--do-send-command cmd)
   (when arg
-    (claude-code--switch-to-claude-buffer)))
+    (switch-to-buffer (claude-code--buffer-name))))
 
 ;;;###autoload
 (defun claude-code-send-command-with-context (cmd &optional arg)
@@ -482,7 +494,7 @@ With prefix ARG, switch to the Claude buffer after sending CMD."
                              cmd)))
     (claude-code--do-send-command cmd-with-context)
     (when arg
-      (claude-code--switch-to-claude-buffer))))
+      (switch-to-buffer (claude-code--buffer-name)))))
 
 ;;;###autoload
 (defun claude-code-send-return ()
@@ -500,7 +512,7 @@ having to switch to the REPL buffer."
 This is useful for saying \"No\" when Claude asks for confirmation without
 having to switch to the REPL buffer."
   (interactive)
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
       (with-current-buffer claude-code-buffer
         (eat-term-send-string eat-terminal (kbd "ESC"))
         (display-buffer claude-code-buffer))
@@ -529,7 +541,7 @@ With prefix ARG, switch to the Claude buffer after sending."
                              file-name error-text)))
         (claude-code--do-send-command command)
         (when arg
-          (claude-code--switch-to-claude-buffer))))))
+          (switch-to-buffer (claude-code--buffer-name)))))))
 
 ;;;###autoload
 (defun claude-code-read-only-mode ()
@@ -542,7 +554,7 @@ enter Claude commands.
 
 Use `claude-code-exit-read-only-mode' to switch back to normal mode."
   (interactive)
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
       (with-current-buffer claude-code-buffer
         (eat-emacs-mode)
         (setq-local eat-invisible-cursor-type claude-code-read-only-mode-cursor-type)
@@ -554,7 +566,7 @@ Use `claude-code-exit-read-only-mode' to switch back to normal mode."
 (defun claude-code-exit-read-only-mode ()
   "Exit read-only mode and return to normal mode (eat semi-char mode)."
   (interactive)
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
       (with-current-buffer claude-code-buffer
         (eat-semi-char-mode)
         (setq-local eat-invisible-cursor-type nil)
@@ -571,7 +583,7 @@ regular buffer. This mode is useful for selecting text in the Claude
 buffer. However, you are not allowed to change the buffer contents or
 enter Claude commands."
   (interactive)
-  (if-let ((claude-code-buffer (claude-code--get-claude-buffer)))
+  (if-let ((claude-code-buffer (get-buffer (claude-code--buffer-name))))
       (with-current-buffer claude-code-buffer
         (if eat--semi-char-mode
             (claude-code-read-only-mode)


### PR DESCRIPTION
@ncaq I made some changes to your PR:

- Removed `claude-code-current-directory` as I don't think it's needed with your changes now - `claude-code` will just do the right thing (start in current project, or current buffer file or dir, or prompt for project dir with prefix arg).
- Fixed a bug where it was prompting for a project directory without a prefix arg. That bug was introduced by my suggestion re using `(current-project t)` sorry - needed to remove the `t`. 
- Merged in latest changes from claude-code.el `main` and resolve conflicts.
- Minor renaming / cleanup.
- Adjusted README and CHANGELOG.